### PR TITLE
Harness CMake `find_package`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,9 +14,7 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra")
 file(GLOB SOURCES *.cpp)
 add_executable(TetrisAttack3D  ${SOURCES})
 
-target_link_libraries(TetrisAttack3D
-    "-lGLU"
-    "-lGL"
-    "-lSDL2"
-    "-lSDL2main"
-	"-lGLEW")
+find_package(GLEW REQUIRED)
+find_package(SDL2 REQUIRED)
+
+target_link_libraries(TetrisAttack3D GLEW::GLEW SDL2::SDL2)


### PR DESCRIPTION
Cool stuff with this game. Was about to embark on a reimpl of this game myself 😎 

Well, about the PR:
The manual `-l*` is not as reliable. By using the target based syntax, more people can effortlessly compile without messing around with paths and env vars.

Also, makes the dependencies very clear 😉 
I know you haven't touched this in a while, but I guess this small change wouldn't require revisiting tons of old code 😄 